### PR TITLE
Adding support for a config file

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,17 +52,17 @@ if(argv.config){
 
       //Assigning options from config to argv (which is being used directly to generate HTML)
       argv.input = configData.input;
-      argv.output = configData.output ? configData.output : './dist';
+      argv.output = configData.output ? configData.output : './dist'; //Does not work due to Issue #12
       argv.lang = configData.lang ? configData.lang : 'en-CA';
 
     }
     else {
-      console.log("Config file must be JSON!", path.extname(argv.config))
+      console.log("Config file must be JSON!", path.extname(argv.config));
       process.exit(-1);
     }
   }
   else {
-    console.log("Config file missing!")
+    console.log("Config file missing!");
     process.exit(-1);
   }
 }

--- a/server.js
+++ b/server.js
@@ -28,9 +28,44 @@ let argv = require('yargs/yargs')(process.argv.slice(2))
     default: '.',
     describe: 'generate the lang attribute',
     type: 'string'
+  },
+  config: {
+    alias: 'c',
+    describe: 'json file to specify options'
   }
 })
 .argv;
+
+//Parse and use config file if present:
+if(argv.config){
+  if(fs.existsSync(argv.config)){
+    if(path.extname(argv.config).toLocaleLowerCase() == '.json'){
+      let fileContents = fs.readFileSync(argv.config);
+
+      try{
+        configData = JSON.parse(fileContents);
+      }
+      catch(err){
+        console.log('Error while parsing JSON: ', err);
+        process.exit(-1);
+      }
+
+      //Assigning options from config to argv (which is being used directly to generate HTML)
+      argv.input = configData.input;
+      argv.output = configData.output ? configData.output : './dist';
+      argv.lang = configData.lang ? configData.lang : 'en-CA';
+
+    }
+    else {
+      console.log("Config file must be JSON!", path.extname(argv.config))
+      process.exit(-1);
+    }
+  }
+  else {
+    console.log("Config file missing!")
+    process.exit(-1);
+  }
+}
 
 // Check ./dist folder
 if(fs.existsSync("./dist")){


### PR DESCRIPTION
### Description
Fixes #31. Added support for a config file using a `--config or -c` flag.

Only 3 command line arguments are currently supported by the program, and I've added support for all three (`input, output and lang`). Also since the program is using the arguments directly through `argv` to generate HTML, I also just assigned the option values to `argv` after parsing the config file for consistency and to avoid touching any of the HTML generation.

### Example:
```
node server.js -c test.json
```
test.json
```
{
    "input": "./Sherlock-Holmes-Selected-Stories",
    "output": "./web",
    "future-feature": "should be ignored for now"
}
```
Program output:
```
File name:  Silver Blaze.txt
File name:  The Adventure of the Six Napoleans.txt
File name:  The Adventure of the Speckled Band.txt
File name:  The Naval Treaty.txt
File name:  The Red Headed League.txt
The HTML files have been saved to ./dist!
Title is : Silver Blaze
Title is : THE ADVENTURE OF THE SPECKLED BAND
Title is : The Naval Treaty
Title is : THE ADVENTURE OF THE SIX NAPOLEONS
Title is : The Red Headed League
```
*(NOTE: There is currently an open **bug** #12  because of which the files were saved to `./dist` instead of `./web`. This is unrealted to this PR, the changes in this PR correctly parse the output directory however it's hardcoded to `./dist` when the HTML is generated. See #12 and #4 .)*
### Implemented the following:
- [x] The -c or --config flags accept a file path to a JSON config file.
- [x] If the file is missing, or can't be parsed as JSON, program exits with an error message.
- [x] If the -c or --config option is provided, any other options on the command line are ignored.
- [x] The program will ignore any options in the config file it doesn't recognize.
- [x] If the config file is missing any options, defaults are used. For example, output defaults to `./dist`.